### PR TITLE
[Performance Optimization] Use dynamic import to import mp3 files

### DIFF
--- a/src/client/src/themes/panda-pizza-pirate/index.js
+++ b/src/client/src/themes/panda-pizza-pirate/index.js
@@ -15,12 +15,15 @@ import BearWinning from './components/winning-animations/bear';
 import themeMusic from './sounds/zazie.mp3';
 import countdownBeep from './sounds/countdown-blip.wav';
 import playerMoveSelected from '../../sounds/move-selected.wav';
-
-import pandaWiningSound from './sounds/panda-win.mp3';
-import pizzaWinningSound from './sounds/pizza-win.mp3';
-import pirateWinningSound from './sounds/pirate-win.mp3';
+// import pandaWiningSound from './sounds/panda-win.mp3';
+// import pizzaWinningSound from './sounds/pizza-win.mp3';
+// import pirateWinningSound from './sounds/pirate-win.mp3';
 
 import ResultAlternateScreen from '../../screens/spectator-screen/components/result-alternate';
+
+const pandaWiningSound = import('./sounds/panda-win.mp3');
+const pizzaWinningSound = import('./sounds/pizza-win.mp3');
+const pirateWinningSound = import('./sounds/pirate-win.mp3');
 
 export default {
   gameplay: {
@@ -66,7 +69,7 @@ export default {
           english: 'Panda dies of high cholesterol',
           chinese: '熊貓死於高膽固醇',
         },
-     ],
+      ],
       B: [
         {
           english: 'He was a nice pirate, until I bit his head off',


### PR DESCRIPTION
![](https://media.giphy.com/media/9gISqB3tncMmY/giphy.gif)

# Reason for this change

- Stop loading the music file on player side

# Overview of the change

- Use dynamic import to import the sound file in `PPP` 

-----

### This one works correctly as I tested!

*Forgot to test the last PR, it didn't solve the issue.* 



