### PR TITLE
Delay load sounds after page render

### DIFF
--- a/src/client/src/screens/spectator-screen/View.js
+++ b/src/client/src/screens/spectator-screen/View.js
@@ -1,23 +1,22 @@
 /* @flow */
 // flow:disable no typedefs for useState, useEffect yet
-import React, { useContext, useState, useEffect } from 'react';
+import React, {useContext, useState, useEffect} from 'react';
 import GameStateContext from '../../contexts/GameStateContext';
 import ServerMessagesContext from '../../contexts/ServerMessagesContext';
 import useGetGameState from '../hooks/useGetGameState';
 import DebugOutput from '../../DebugOutput';
-import Switch from '../../components/switch'
+import Switch from '../../components/switch';
 
 import Waiting from './components/waiting';
 import Loading from './components/loading';
 import Ready from './components/ready';
-import Result from './components/result-alternate';
 import Countdown from './components/countdown';
 import {SOUND_KEYS} from '../../sounds/SoundService';
 import GameSoundContext from '../../contexts/GameSoundContext';
-import { GameSettingsDrawer } from '../../game-settings';
+import {GameSettingsDrawer} from '../../game-settings';
 import GameThemeContext from '../../contexts/GameThemeContext';
 
-const waitingStatuses = [ 'EMPTY', 'WAITING_FOR_PLAYER_1', 'WAITING_FOR_PLAYER_2' ];
+const waitingStatuses = ['EMPTY', 'WAITING_FOR_PLAYER_1', 'WAITING_FOR_PLAYER_2'];
 
 const View = () => {
   const [showCountdown, setShowCountdown] = useState(null);
@@ -26,10 +25,12 @@ const View = () => {
   const soundService = useContext(GameSoundContext);
   const theme = useContext(GameThemeContext);
 
+  soundService.load();
+
   useEffect(() => {
-    if(gameState && gameState.status === 'FINISHED' ) {
+    if (gameState && gameState.status === 'FINISHED') {
       setShowCountdown(true);
-      setTimeout(()=> {
+      setTimeout(() => {
         setShowCountdown(false);
       }, 3500);
     }
@@ -40,7 +41,7 @@ const View = () => {
       soundService.stop(SOUND_KEYS.WAITING_MUSIC);
     }
 
-    if(gameState && gameState.status !== 'FINISHED' ) {
+    if (gameState && gameState.status !== 'FINISHED') {
       soundService.play(SOUND_KEYS.WAITING_MUSIC);
     }
   }, [gameState]);
@@ -48,7 +49,7 @@ const View = () => {
   useEffect(() => {
     //Um, pretty bad logic but it'll do. Play a sound if user makes selection
     if (gameState &&
-      (gameState.status === 'WAITING_FOR_PLAYER_1' || gameState.status === 'WAITING_FOR_PLAYER_2'| gameState.status === 'READY')) {
+      (gameState.status === 'WAITING_FOR_PLAYER_1' || gameState.status === 'WAITING_FOR_PLAYER_2' | gameState.status === 'READY')) {
       soundService.play(SOUND_KEYS.PLAYER_MOVED_SELECTED);
     }
   }, [gameState]);
@@ -60,7 +61,7 @@ const View = () => {
   const resetGame = () => {
     soundService.stopAll();
     serverMessages.resetGame();
-  }
+  };
 
   return (
     <React.Fragment>
@@ -71,18 +72,18 @@ const View = () => {
             <Waiting
               showIf={waitingStatuses.includes(gameState.status)}
               player1={gameState.player1}
-              player2={gameState.player2} />
+              player2={gameState.player2}/>
             <Ready
-              showIf={gameState.status==='READY'}
+              showIf={gameState.status === 'READY'}
               player1={gameState.player1}
               player2={gameState.player2}
               playGame={serverMessages.playGame}
             />
             <Countdown
-              showIf={gameState.status==='FINISHED' && (showCountdown !== null && showCountdown === true)}
+              showIf={gameState.status === 'FINISHED' && (showCountdown !== null && showCountdown === true)}
             />
             <ResultScreenComponent
-              showIf={gameState.status==='FINISHED' && (showCountdown !== null && showCountdown === false)}
+              showIf={gameState.status === 'FINISHED' && (showCountdown !== null && showCountdown === false)}
               result={gameState.result}
               player1={gameState.player1}
               player2={gameState.player2}
@@ -90,13 +91,13 @@ const View = () => {
             />
           </Switch>
         ) : (
-          <Loading />
+          <Loading/>
         )
       }
 
-      <DebugOutput data={ gameState } />
+      <DebugOutput data={gameState}/>
     </React.Fragment>
-  )
-}
+  );
+};
 
 export default View;

--- a/src/client/src/sounds/SoundService.js
+++ b/src/client/src/sounds/SoundService.js
@@ -1,4 +1,4 @@
-import { Howl } from 'howler';
+import {Howl} from 'howler';
 import drawSound from './draw.mp3';
 import pointsSound from './points.mp3';
 
@@ -21,46 +21,60 @@ export class SoundService {
       throw new Error('Sound Service requires a theme');
     }
     this._theme = theme;
+    this._loaded = false;
     this._musicEnabled = musicEnabled;
 
-    //Pre-load sounds
-    this._sounds[SOUND_KEYS.WAITING_MUSIC] = {
-      resumeable: true,
-      sound: new Howl({
-        src: [theme.sounds.waitingMusic],
-        loop: true,
-        volume: 0.6,
-      }),
-    };
-
-    this._sounds[SOUND_KEYS.POINTS_INCREASE] = {
-      sound: new Howl({ src: [pointsSound] }),
-    };
-
-    this._sounds[SOUND_KEYS.COUNTDOWN_BLIP] = {
-      sound: new Howl({ src: [theme.sounds.countdownBeep] }),
-    };
-
-    this._sounds[SOUND_KEYS.PLAYER_MOVED_SELECTED] = {
-      sound: new Howl({ src: [theme.sounds.playerMoveSelected] }),
-    };
-
-    this._sounds[SOUND_KEYS.DRAW] = {
-      sound: new Howl({ src: [drawSound] }),
-    };
-
-    //Pre-load winning sounds
-    Object.keys(this._theme.characters.winningSoundMapping).forEach(key => {
-      console.log('Adding sound for key', key);
-      this._sounds[key] = {
-        sound: new Howl({
-          src: [this._theme.characters.winningSoundMapping[key]],
-        }),
-        resumeable: true,
-      };
-    });
-
     console.log('SOUNDS', this._sounds);
+  }
+
+  load() {
+    if (!this._loaded) {
+      console.log('Load sounds');
+
+      this._loaded = true;
+      //Pre-load sounds
+      this._sounds[SOUND_KEYS.WAITING_MUSIC] = {
+        resumeable: true,
+        sound: new Howl({
+          src: [this._theme.sounds.waitingMusic],
+          loop: true,
+          volume: 0.6,
+        }),
+      };
+
+      this._sounds[SOUND_KEYS.POINTS_INCREASE] = {
+        sound: new Howl({
+          src: [pointsSound],
+        }),
+      };
+
+      this._sounds[SOUND_KEYS.COUNTDOWN_BLIP] = {
+        sound: new Howl({
+          src: [this._theme.sounds.countdownBeep],
+        }),
+      };
+
+      this._sounds[SOUND_KEYS.PLAYER_MOVED_SELECTED] = {
+        sound: new Howl({
+          src: [this._theme.sounds.playerMoveSelected],
+        }),
+      };
+
+      this._sounds[SOUND_KEYS.DRAW] = {
+        sound: new Howl({src: [drawSound]}),
+      };
+
+      //Pre-load winning sounds
+      Object.keys(this._theme.characters.winningSoundMapping).forEach(key => {
+        console.log('Adding sound for key', key);
+        this._sounds[key] = {
+          sound: new Howl({
+            src: [this._theme.characters.winningSoundMapping[key]],
+          }),
+          resumeable: true,
+        };
+      });
+    }
   }
 
   setMusicEnabled(enabled) {
@@ -81,6 +95,8 @@ export class SoundService {
 
   play(soundKey, forceIfStillPlaying = false) {
     //Place sound in resumable sounds in case music gets turned on
+    console.log('Play', soundKey);
+
     if (
       this._sounds[soundKey].resumeable &&
       !this._resumableSoundKeys.includes(soundKey)
@@ -109,7 +125,7 @@ export class SoundService {
   stopAll() {
     Object.keys(this._sounds).forEach(key => {
       this._sounds[key].sound.stop();
-    })
+    });
   }
 
   playWinningSound(winningMove, isDraw) {


### PR DESCRIPTION
Currently, the sounds are loaded with the other files together, they occupy some bandwidth and slow the page render. This PR implement that loading the sounds files after pager render.