### PR TITLE
Record moar game stats

### DIFF
--- a/src/client/src/onGameComplete.js
+++ b/src/client/src/onGameComplete.js
@@ -67,14 +67,11 @@ export const onGameComplete = (
   if (gameResult.draw) {
     const playerToAwardPowerUpTo = getWeightedRandomPlayer(localUpdatedScores);
     const randomPowerUp = getWeightedRandomPowerUp();
-    console.log(
-      'onGameComplete: awardPowerUp',
-      playerToAwardPowerUpTo,
-      randomPowerUp
-    );
 
     awardPowerUpToPlayer(playerToAwardPowerUpTo, randomPowerUp);
     awardedPowerUps[playerToAwardPowerUpTo] = randomPowerUp;
+
+    console.log('onGameComplete: awardPowerUp', awardedPowerUps);
   }
 
   // check trophy points
@@ -104,5 +101,10 @@ export const onGameComplete = (
     adjustCounter('BONUS', trophyAdjustedPointsAssigned.bonus),
   ]).then(/* What to do here? */);
 
-  onComplete(localUpdatedScores, awardedPowerUps, trophyWinner);
+  onComplete(
+    localUpdatedScores,
+    powerUpAdjustedPointsAssigned,
+    awardedPowerUps,
+    trophyWinner
+  );
 };

--- a/src/client/src/sockets/generateServerMessagesService.js
+++ b/src/client/src/sockets/generateServerMessagesService.js
@@ -10,8 +10,12 @@ const generateServerMessagesService = (socket: Object): ServerMessages => {
         payload: { slot: player, move, powerUp, avatar },
       }),
     resetGame: () => socket.emit('RESET_GAME', { type: 'RESET_GAME' }),
-    playGame: themeName =>
-      socket.emit('RUN_GAME', { type: 'RUN_GAME', payload: { themeName } }),
+    playGame: () => socket.emit('RUN_GAME', { type: 'RUN_GAME' }),
+    saveGameStats: (themeName, pointsAwarded, powerUpsAwarded, trophyAwarded) =>
+      socket.emit('SAVE_GAME_STATS', {
+        type: 'SAVE_GAME_STATS',
+        payload: { themeName, pointsAwarded, powerUpsAwarded, trophyAwarded },
+      }),
     awardPowerUps: powerUps =>
       socket.emit('AWARDED_POWERUPS', {
         type: 'AWARDED_POWERUPS',

--- a/src/server/src/messages/typeConstants.js
+++ b/src/server/src/messages/typeConstants.js
@@ -15,6 +15,7 @@ const GET_GAME_VIEW = 'GET_GAME_VIEW';
 const RUN_GAME = 'RUN_GAME';
 const GAME_FINISHED = 'GAME_FINISHED';
 const AWARDED_POWERUPS = 'AWARDED_POWERUPS';
+const SAVE_GAME_STATS = 'SAVE_GAME_STATS';
 
 export const incomingMessageTypes = {
   MAKE_MOVE,
@@ -24,6 +25,7 @@ export const incomingMessageTypes = {
   GET_GAME_VIEW,
   RUN_GAME,
   AWARDED_POWERUPS,
+  SAVE_GAME_STATS,
 };
 
 export const outgoingMessageTypes = {

--- a/src/server/src/receiveMessage.js
+++ b/src/server/src/receiveMessage.js
@@ -78,7 +78,7 @@ const receiveMessage = (store: Store, msg: Message, sendToClient: SendToClient):
       const gameResult = runGame(store.getState());
       store.dispatch(updateGameResultAction(gameResult));
       store.dispatch(updateGameStatusAction(GAME_STATUS.FINISHED));
-      addStatsEntry(mapGameStateToStats(store.getState(), prop('themeName', msg.payload)));
+
       sendToClient(gameCompleteMessage(store.getState()));
       sendToClient(publishGameView(store.getState()));
     }
@@ -96,6 +96,20 @@ const receiveMessage = (store: Store, msg: Message, sendToClient: SendToClient):
     }
       break;
 
+    case incomingMessageTypes.SAVE_GAME_STATS: {
+      console.log('------------ SAVE GAME STATS ----------------', msg.payload);
+      addStatsEntry(
+        mapGameStateToStats(
+          store.getState(),
+          prop('themeName', msg.payload),
+          prop('pointsAwarded', msg.payload),
+          prop('powerUpsAwarded', msg.payload),
+          prop('trophyAwarded', msg.payload),
+        )
+      );
+    }
+      break;
+  
     default: {
       sendToClient(invalidMessageMessage());
     }

--- a/src/server/src/stats/index.js
+++ b/src/server/src/stats/index.js
@@ -17,22 +17,48 @@ const s3 = new AWS.S3({
   apiVersion: '2006-03-01',
 });
 
-const mapPlayerToStats = (player: Player, winner: boolean): PlayerStats => {
+const mapPlayerToStats = (
+  player: Player,
+  winner: boolean,
+  points: number,
+  powerUpAwarded: string,
+  trophy: boolean
+): PlayerStats => {
   return {
     team: player.name,
     move: player.move,
-    powerUp: player.powerUp,
+    powerUpUsed: player.powerUp,
     player: player.avatar.name,
     winner,
+    points,
+    powerUpAwarded,
+    trophy,
   };
 };
 
-export const mapGameStateToStats = (game: Game, theme: string): GameStats => {
-
+export const mapGameStateToStats = (
+  game: Game,
+  theme: string,
+  pointsAwarded,
+  powerUpsAwarded,
+  trophyAwarded: string
+): GameStats => {
   return {
     date: new Date().toISOString(),
-    player1: mapPlayerToStats(game.player1, game.result.winner === 'player1'),
-    player2: mapPlayerToStats(game.player2, game.result.winner === 'player2'),
+    player1: mapPlayerToStats(
+      game.player1,
+      game.result.winner === 'player1',
+      pointsAwarded.player1,
+      powerUpsAwarded.player1,
+      trophyAwarded === 'player1'
+    ),
+    player2: mapPlayerToStats(
+      game.player2,
+      game.result.winner === 'player2',
+      pointsAwarded.player2,
+      powerUpsAwarded.player2,
+      trophyAwarded === 'player2'
+    ),
     theme,
     result: {
       draw: game.result.draw,


### PR DESCRIPTION
![](https://media.giphy.com/media/9ADoZQgs0tyww/giphy.gif)

# Overview of change

- Move game stats call to separate event, triggered from client
- Pass theme, points awarded, PowerUps awarded and trophies awarded to stats
- Record extra info against player stats

### Game result record

### Win

```json
{
  "date": "2019-04-26T22:48:42.393Z",
  "player1": {
    "team": "XIAN",
    "move": "C",
    "powerUpUsed": "STEAL",
    "player": "Bin",
    "winner": false,
    "points": 0,
    "trophy": false
  },
  "player2": {
    "team": "MELB",
    "move": "B",
    "powerUpUsed": "NONE",
    "player": "Andy",
    "winner": true,
    "points": 1,
    "trophy": false
  },
  "theme": "Ninja, Cowboy, Bear",
  "result": {
    "draw": false,
    "winner": "player2"
  }
}
```

### Draw
```json
{
  "date": "2019-04-26T22:53:14.947Z",
  "player1": {
    "team": "XIAN",
    "move": "A",
    "powerUpUsed": "STEAL",
    "player": "Shuming",
    "winner": false,
    "points": 0,
    "trophy": false
  },
  "player2": {
    "team": "MELB",
    "move": "A",
    "powerUpUsed": "NONE",
    "player": "Duyen",
    "winner": false,
    "points": 0,
    "powerUpAwarded": "STEAL",
    "trophy": false
  },
  "theme": "Ninja, Cowboy, Bear",
  "result": {
    "draw": true
  }
}
```