### PR TITLE
Show leaderboard ranked by Wins

### DIFF
--- a/src/client/src/screens/player-stats/View.js
+++ b/src/client/src/screens/player-stats/View.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import FullPage from '../../components/page-layout/FullPage';
 import { PageSubTitle } from '../styled';
 import { STATS_API_BASE_URL } from '../../environment';
@@ -16,6 +16,11 @@ const fetchRankings = () => {
   });
 };
 
+const RankingItemEnterAnimation = keyframes`
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+`;
+
 const RankingScrollableContainer = styled.div`
   max-height: 65vh;
   overflow-y: scroll;
@@ -30,25 +35,33 @@ const RankingContainer = styled.div`
 const RankingItem = styled.div`
   display: grid;
   grid-template-columns: 25% 50% 25%;
-  background-color: #1e0f1c;
+  background-color: rgba(30, 15, 28, 0.8);
   border-radius: 7px;
   margin-bottom: 10px;
   align-items: center;
   padding: 5px 0;
-  opacity: 0.8;
-  font-size: 0.8rem;
+  font-size: 0.6rem;
+  animation: ${RankingItemEnterAnimation} 1s ease-in
+    ${props => (props.position > 10 ? 0 : 10 - props.position) * 700}ms 1 both;
   ${props =>
-    props.feature && 'font-size: 1.2rem; font-weight: bold; opacity: 1;'}
+    props.feature &&
+    'font-size: 1.2rem; font-weight: bold; background-color: rgba(30,15,28, 1);'}
 `;
 const RankingPlace = styled.div`
   color: #fff;
+  opacity: 0.8;
+  ${props => props.feature && 'opacity: 1;'}
 `;
 const RankingPlayerName = styled.div`
   color: #e2e9c0;
+  opacity: 0.8;
+  ${props => props.feature && 'opacity: 1;'}
 `;
 const RankingScore = styled.div`
   justify-self: center;
   color: #7aa95c;
+  opacity: 0.8;
+  ${props => props.feature && 'opacity: 1;'}
 `;
 
 const Link = styled.a`
@@ -88,12 +101,21 @@ const View = () => {
       <RankingScrollableContainer>
         <RankingContainer>
           {rankingList.result.map((ranking, index) => {
+            if (ranking.player === 'Guest') {
+              // TODO: filter guest out on server
+              return null;
+            }
             const isFirst = index === 0;
             const firstEqual =
               ranking.times_won === rankingList.result[0].times_won;
             const featureRow = isFirst || firstEqual;
             return (
-              <RankingItem feature={featureRow} key={ranking.player}>
+              <RankingItem
+                feature={featureRow}
+                key={ranking.player}
+                totalRankings={rankingList.result.length}
+                position={index}
+              >
                 <RankingPlace
                   feature={featureRow}
                   style={{ textAlign: 'center' }}

--- a/src/client/src/screens/player-stats/View.js
+++ b/src/client/src/screens/player-stats/View.js
@@ -16,6 +16,11 @@ const fetchRankings = () => {
   });
 };
 
+const RankingScrollableContainer = styled.div`
+  max-height: 70vh;
+  overflow-y: scroll;
+`;
+
 const RankingTable = styled.table`
   width: 90vw;
   max-width: 960px;
@@ -52,6 +57,14 @@ const Link = styled.a`
   text-align: center;
 `;
 
+const getWinningPercentage = (timesPlayed, timesWon) => {
+  if (timesPlayed === 0) {
+    return 0;
+  }
+
+  return Math.floor((timesWon / timesPlayed) * 100);
+};
+
 const View = () => {
   const [rankingList, setRankingList] = useState([]);
   const soundService = useContext(GameSoundContext);
@@ -69,38 +82,46 @@ const View = () => {
     <FullPage pageTitle="Leaderboard">
       <GameSettingsDrawer />
       <PageSubTitle>Ranking by Total Points Won</PageSubTitle>
-      <RankingTable>
-        <RankingTableBody>
-          {rankingList.map((ranking, index) => {
-            const isFirst = index === 0;
-            const firstEqual = ranking.points === rankingList[0].points;
-            const featureRow = isFirst || firstEqual;
-            return (
-              <RankingTableRow key={ranking.player}>
-                <RankingTableCell
-                  feature={featureRow}
-                  style={{ textAlign: 'center' }}
-                >
-                  {featureRow ? '🥇' : `${index + 1}.`}
-                </RankingTableCell>
-                <RankingTableCell feature={featureRow}>
-                  {featureRow ? (
-                    <RainbowText>{ranking.player}</RainbowText>
-                  ) : (
-                    ranking.player
-                  )}
-                </RankingTableCell>
-                <RankingTableCell
-                  feature={featureRow}
-                  style={{ textAlign: 'center' }}
-                >
-                  {ranking.points}
-                </RankingTableCell>
-              </RankingTableRow>
-            );
-          })}
-        </RankingTableBody>
-      </RankingTable>
+      <RankingScrollableContainer>
+        <RankingTable>
+          <RankingTableBody>
+            {rankingList.map((ranking, index) => {
+              const isFirst = index === 0;
+              const firstEqual =
+                ranking.points_won === rankingList[0].points_won;
+              const featureRow = isFirst || firstEqual;
+              return (
+                <RankingTableRow key={ranking.player}>
+                  <RankingTableCell
+                    feature={featureRow}
+                    style={{ textAlign: 'center' }}
+                  >
+                    {featureRow ? '🥇' : `${index + 1}.`}
+                  </RankingTableCell>
+                  <RankingTableCell feature={featureRow}>
+                    {featureRow ? (
+                      <RainbowText>{ranking.player}</RainbowText>
+                    ) : (
+                      ranking.player
+                    )}
+                  </RankingTableCell>
+                  <RankingTableCell
+                    feature={featureRow}
+                    style={{ textAlign: 'center' }}
+                  >
+                    {ranking.points_won} (
+                    {getWinningPercentage(
+                      ranking.times_played,
+                      ranking.times_won
+                    )}
+                    % )
+                  </RankingTableCell>
+                </RankingTableRow>
+              );
+            })}
+          </RankingTableBody>
+        </RankingTable>
+      </RankingScrollableContainer>
       <Link href="/">Back to game</Link>
     </FullPage>
   );

--- a/src/client/src/screens/player-stats/View.js
+++ b/src/client/src/screens/player-stats/View.js
@@ -30,19 +30,25 @@ const RankingContainer = styled.div`
 const RankingItem = styled.div`
   display: grid;
   grid-template-columns: 25% 50% 25%;
-  background-color: #ccc;
+  background-color: #1e0f1c;
   border-radius: 7px;
   margin-bottom: 10px;
   align-items: center;
+  padding: 5px 0;
   opacity: 0.8;
   font-size: 0.8rem;
   ${props =>
     props.feature && 'font-size: 1.2rem; font-weight: bold; opacity: 1;'}
 `;
-const RankingPlace = styled.div``;
-const RankingPlayerName = styled.div``;
+const RankingPlace = styled.div`
+  color: #fff;
+`;
+const RankingPlayerName = styled.div`
+  color: #e2e9c0;
+`;
 const RankingScore = styled.div`
   justify-self: center;
+  color: #7aa95c;
 `;
 
 const Link = styled.a`

--- a/src/client/src/screens/player-stats/View.js
+++ b/src/client/src/screens/player-stats/View.js
@@ -21,31 +21,28 @@ const RankingScrollableContainer = styled.div`
   overflow-y: scroll;
 `;
 
-const RankingTable = styled.table`
+const RankingContainer = styled.div`
   width: 90vw;
   max-width: 960px;
   margin: 0 auto;
-  border: 0;
-  border-collapse: collapse;
-  font-size: 0.6rem;
 `;
 
-const RankingTableBody = styled.tbody`
-  tr:nth-child(odd) {
-    background-color: #ccc;
-  }
-`;
-
-const RankingTableRow = styled.tr`
-  margin: 0;
-`;
-
-const RankingTableCell = styled.td`
-  margin: 0;
-  padding: 10px;
+const RankingItem = styled.div`
+  display: grid;
+  grid-template-columns: 25% 50% 25%;
+  background-color: #ccc;
+  border-radius: 7px;
+  margin-bottom: 10px;
+  align-items: center;
   opacity: 0.8;
+  font-size: 0.8rem;
   ${props =>
     props.feature && 'font-size: 1.2rem; font-weight: bold; opacity: 1;'}
+`;
+const RankingPlace = styled.div``;
+const RankingPlayerName = styled.div``;
+const RankingScore = styled.div`
+  justify-self: center;
 `;
 
 const Link = styled.a`
@@ -83,39 +80,34 @@ const View = () => {
       <GameSettingsDrawer />
       <PageSubTitle>{rankingList.title}</PageSubTitle>
       <RankingScrollableContainer>
-        <RankingTable>
-          <RankingTableBody>
-            {rankingList.result.map((ranking, index) => {
-              const isFirst = index === 0;
-              const firstEqual =
-                ranking.times_won === rankingList.result[0].times_won;
-              const featureRow = isFirst || firstEqual;
-              return (
-                <RankingTableRow key={ranking.player}>
-                  <RankingTableCell
-                    feature={featureRow}
-                    style={{ textAlign: 'center' }}
-                  >
-                    {featureRow ? '🥇' : `${index + 1}.`}
-                  </RankingTableCell>
-                  <RankingTableCell feature={featureRow}>
-                    {featureRow ? (
-                      <RainbowText>{ranking.player}</RainbowText>
-                    ) : (
-                      ranking.player
-                    )}
-                  </RankingTableCell>
-                  <RankingTableCell
-                    feature={featureRow}
-                    style={{ textAlign: 'center' }}
-                  >
-                    {ranking.times_won}
-                  </RankingTableCell>
-                </RankingTableRow>
-              );
-            })}
-          </RankingTableBody>
-        </RankingTable>
+        <RankingContainer>
+          {rankingList.result.map((ranking, index) => {
+            const isFirst = index === 0;
+            const firstEqual =
+              ranking.times_won === rankingList.result[0].times_won;
+            const featureRow = isFirst || firstEqual;
+            return (
+              <RankingItem feature={featureRow} key={ranking.player}>
+                <RankingPlace
+                  feature={featureRow}
+                  style={{ textAlign: 'center' }}
+                >
+                  {featureRow ? '🥇' : `${index + 1}.`}
+                </RankingPlace>
+                <RankingPlayerName feature={featureRow}>
+                  {featureRow ? (
+                    <RainbowText>{ranking.player}</RainbowText>
+                  ) : (
+                    ranking.player
+                  )}
+                </RankingPlayerName>
+                <RankingScore feature={featureRow}>
+                  {ranking.times_won}
+                </RankingScore>
+              </RankingItem>
+            );
+          })}
+        </RankingContainer>
       </RankingScrollableContainer>
       <Link href="/">Back to game</Link>
     </FullPage>

--- a/src/client/src/screens/player-stats/View.js
+++ b/src/client/src/screens/player-stats/View.js
@@ -17,7 +17,7 @@ const fetchRankings = () => {
 };
 
 const RankingScrollableContainer = styled.div`
-  max-height: 70vh;
+  max-height: 65vh;
   overflow-y: scroll;
 `;
 
@@ -57,16 +57,16 @@ const Link = styled.a`
   text-align: center;
 `;
 
-const getWinningPercentage = (timesPlayed, timesWon) => {
-  if (timesPlayed === 0) {
-    return 0;
-  }
+// const getWinningPercentage = (timesPlayed, timesWon) => {
+//   if (timesPlayed === 0) {
+//     return 0;
+//   }
 
-  return Math.floor((timesWon / timesPlayed) * 100);
-};
+//   return Math.floor((timesWon / timesPlayed) * 100);
+// };
 
 const View = () => {
-  const [rankingList, setRankingList] = useState([]);
+  const [rankingList, setRankingList] = useState({ title: '', result: [] });
   const soundService = useContext(GameSoundContext);
   soundService.loadScoreboard();
 
@@ -74,21 +74,21 @@ const View = () => {
     console.log('SOUND', soundService);
     soundService.play(SOUND_KEYS.SCOREBOARD_MUSIC);
     fetchRankings().then(rankings => {
-      setRankingList(rankings.result);
+      setRankingList(rankings);
     });
   }, []);
 
   return (
     <FullPage pageTitle="Leaderboard">
       <GameSettingsDrawer />
-      <PageSubTitle>Ranking by Total Points Won</PageSubTitle>
+      <PageSubTitle>{rankingList.title}</PageSubTitle>
       <RankingScrollableContainer>
         <RankingTable>
           <RankingTableBody>
-            {rankingList.map((ranking, index) => {
+            {rankingList.result.map((ranking, index) => {
               const isFirst = index === 0;
               const firstEqual =
-                ranking.points_won === rankingList[0].points_won;
+                ranking.times_won === rankingList.result[0].times_won;
               const featureRow = isFirst || firstEqual;
               return (
                 <RankingTableRow key={ranking.player}>
@@ -109,12 +109,7 @@ const View = () => {
                     feature={featureRow}
                     style={{ textAlign: 'center' }}
                   >
-                    {ranking.points_won} (
-                    {getWinningPercentage(
-                      ranking.times_played,
-                      ranking.times_won
-                    )}
-                    % )
+                    {ranking.times_won}
                   </RankingTableCell>
                 </RankingTableRow>
               );

--- a/src/server/src/stats/player-leaderboard-query.js
+++ b/src/server/src/stats/player-leaderboard-query.js
@@ -1,0 +1,40 @@
+export const playerLeaderboardQuery = `SELECT *
+FROM 
+    (SELECT a.player,
+         a.times_played,
+         coalesce(b.times_won,
+         0) AS times_won,
+         a.points_won
+    FROM 
+        (SELECT player1.player,
+         count(*) AS times_played,
+         sum(player1.points) AS points_won
+        FROM game_result
+        GROUP BY  player1.player) a
+        LEFT JOIN 
+            (SELECT player1.player,
+         count(*) AS times_won
+            FROM game_result
+            WHERE player1.winner
+            GROUP BY  player1.player) b
+                ON a.player=b.player)
+        UNION ALL
+        (SELECT c.player,
+         c.times_played,
+         coalesce(d.times_won,
+         0) AS times_won,
+         c.points_won
+        FROM 
+            (SELECT player2.player,
+         count(*) AS times_played,
+         sum(player2.points) AS points_won
+            FROM game_result
+            GROUP BY  player2.player) c
+            LEFT JOIN 
+                (SELECT player2.player,
+         count(*) AS times_won
+                FROM game_result
+                WHERE player2.winner
+                GROUP BY player2.player) d
+                    ON c.player=d.player)
+            ORDER BY  points_won desc, times_won desc, times_played desc, player;`;

--- a/src/server/src/stats/player-leaderboard-query.js
+++ b/src/server/src/stats/player-leaderboard-query.js
@@ -1,40 +1,39 @@
-export const playerLeaderboardQuery = `SELECT *
-FROM 
-    (SELECT a.player,
+export const playerLeaderboardQuery = `SELECT * FROM
+(SELECT a.player,
          a.times_played,
          coalesce(b.times_won,
          0) AS times_won,
-         a.points_won
-    FROM 
-        (SELECT player1.player,
+         a.total_points
+FROM 
+    (SELECT player1.player,
          count(*) AS times_played,
-         sum(player1.points) AS points_won
-        FROM game_result
-        GROUP BY  player1.player) a
-        LEFT JOIN 
-            (SELECT player1.player,
+         sum(player1.points) AS total_points
+    FROM game_result
+    GROUP BY  player1.player) a
+LEFT JOIN 
+    (SELECT player1.player,
          count(*) AS times_won
-            FROM game_result
-            WHERE player1.winner
-            GROUP BY  player1.player) b
-                ON a.player=b.player)
-        UNION ALL
-        (SELECT c.player,
-         c.times_played,
-         coalesce(d.times_won,
+    FROM game_result
+    WHERE player1.winner
+    GROUP BY  player1.player) b
+    ON a.player=b.player)
+UNION ALL
+(SELECT a.player,
+         a.times_played,
+         coalesce(b.times_won,
          0) AS times_won,
-         c.points_won
-        FROM 
-            (SELECT player2.player,
+         a.total_points
+FROM 
+    (SELECT player2.player,
          count(*) AS times_played,
-         sum(player2.points) AS points_won
-            FROM game_result
-            GROUP BY  player2.player) c
-            LEFT JOIN 
-                (SELECT player2.player,
+         sum(player2.points) AS total_points
+    FROM game_result
+    GROUP BY  player2.player) a
+LEFT JOIN 
+    (SELECT player2.player,
          count(*) AS times_won
-                FROM game_result
-                WHERE player2.winner
-                GROUP BY player2.player) d
-                    ON c.player=d.player)
-            ORDER BY  points_won desc, times_won desc, times_played desc, player;`;
+    FROM game_result
+    WHERE player2.winner
+    GROUP BY  player2.player) b
+    ON a.player=b.player)
+    ORDER BY times_won desc, total_points desc, times_played desc, player;`;

--- a/src/server/src/stats/publishStats.js
+++ b/src/server/src/stats/publishStats.js
@@ -40,7 +40,7 @@ const runTestQuery = () => {
       statsS3Bucket.saveStats(
         STATS_AWS_RESULT_BUCKET_NAME,
         'players-by-points-ranking.json',
-        { result: data }
+        { result: data, title: 'Ranking by number of games won' }
       );
     })
     .catch(e => {

--- a/src/server/src/stats/publishStats.js
+++ b/src/server/src/stats/publishStats.js
@@ -8,6 +8,7 @@ import {
   STATS_AWS_RESULT_BUCKET_NAME,
 } from '../environment';
 import { statsS3Bucket } from './s3';
+import {playerLeaderboardQuery} from './player-leaderboard-query';
 
 const RESULT_SIZE = 1000;
 const POLL_INTERVAL = 1000;
@@ -30,30 +31,16 @@ let q = Queue((id, cb) => {
     });
 }, 5);
 
-const playersByPointsQuery = `SELECT player,
-points
-FROM 
-(SELECT player1.player,
-sum(player1.points) AS points
-FROM "game_result"
-GROUP BY  player1.player
-UNION ALL
-SELECT player2.player,
-sum(player2.points) AS points
-FROM "game_result"
-GROUP BY  player2.player ) AS DistinctCodes (player, points)
-WHERE player IS NOT NULL
-ORDER BY  points DESC, player;`;
 
 /* Make a SQL query and display results */
 const runTestQuery = () => {
-  makeQuery(playersByPointsQuery)
+  makeQuery(playerLeaderboardQuery)
     .then(data => {
       console.log('DATA: ', data);
       statsS3Bucket.saveStats(
         STATS_AWS_RESULT_BUCKET_NAME,
         'players-by-points-ranking.json',
-        { result: data },
+        { result: data }
       );
     })
     .catch(e => {


### PR DESCRIPTION
![](https://media.giphy.com/media/yznEXxtq7wQlG/giphy.gif)

# Reason for change

Change ranking of leaderboard from "total points won" to "total wins" to be a bit more fairer.

![Screen Shot 2019-05-11 at 5 51 39 pm](https://user-images.githubusercontent.com/35903460/57566946-9b4a8c00-7415-11e9-94d0-acd64839966c.png)

# Overview of changes

- Update query which generates stats to include _total points won_, _total games played_ and _total games won_
- Update front-end to use `games_won` field to display results
- Refactored Leaderboard from html table to css-grid markup
- Add fade-in animation to Leaderboard list

