### PR TITLE
Add win/loss/draw stats to leaderboard display

### DIFF
--- a/src/client/src/screens/player-stats/SubStatItem.js
+++ b/src/client/src/screens/player-stats/SubStatItem.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ReadableNumberFont } from '../../components/ReadableNumberFont';
+
+const Container = styled.dl`
+  margin: 0;
+  padding: 4px 8px;
+  background-color: ${props => props.style.bgColor};
+  color: white;
+  border-radius: 7px;
+`;
+
+const Title = styled.dt`
+  font-size: 0.4rem;
+  margin: 0;
+  padding: 0;
+  text-align: center;
+`;
+
+const Value = styled.dd`
+  margin: 0;
+  padding: 0;
+  text-align: center;
+  line-height: 1;
+`;
+
+const styles = {
+  wins: {
+    bgColor: '#5cb85c',
+  },
+  losses: {
+    bgColor: '#DF562C',
+  },
+  draws: {
+    bgColor: '#E99D44',
+  },
+};
+
+export const SubStatItem = ({ title, value, type = 'wins' }) => {
+  return (
+    <Container style={styles[type]}>
+      <Title>{title}</Title>
+      <Value>
+        <ReadableNumberFont>{value}</ReadableNumberFont>
+      </Value>
+    </Container>
+  );
+};

--- a/src/client/src/screens/player-stats/View.js
+++ b/src/client/src/screens/player-stats/View.js
@@ -1,12 +1,13 @@
 import React, { useEffect, useState, useContext } from 'react';
 import styled, { keyframes } from 'styled-components';
 import FullPage from '../../components/page-layout/FullPage';
-import { PageSubTitle } from '../styled';
 import { STATS_API_BASE_URL } from '../../environment';
 import RainbowText from '../../components/rainbow-text';
 import GameSoundContext from '../../contexts/GameSoundContext';
 import { SOUND_KEYS } from '../../sounds/SoundService';
 import { GameSettingsDrawer } from '../../game-settings';
+import { SubStatItem } from './SubStatItem';
+import { ReadableNumberFont } from '../../components/ReadableNumberFont';
 
 const fetchRankings = () => {
   return fetch(`${STATS_API_BASE_URL}/players-by-points-ranking.json`, {
@@ -22,7 +23,7 @@ const RankingItemEnterAnimation = keyframes`
 `;
 
 const RankingScrollableContainer = styled.div`
-  max-height: 65vh;
+  max-height: 70vh;
   overflow-y: scroll;
 `;
 
@@ -34,15 +35,15 @@ const RankingContainer = styled.div`
 
 const RankingItem = styled.div`
   display: grid;
-  grid-template-columns: 25% 50% 25%;
+  grid-template-columns: 25% 40% 35%;
   background-color: rgba(30, 15, 28, 0.8);
   border-radius: 7px;
   margin-bottom: 10px;
   align-items: center;
   padding: 5px 0;
-  font-size: 0.6rem;
+  font-size: 0.7rem;
   animation: ${RankingItemEnterAnimation} 1s ease-in
-    ${props => (props.position > 10 ? 0 : 10 - props.position) * 700}ms 1 both;
+    ${props => (props.position > 8 ? 0 : 8 - props.position) * 700}ms 1 both;
   ${props =>
     props.feature &&
     'font-size: 1.2rem; font-weight: bold; background-color: rgba(30,15,28, 1);'}
@@ -52,16 +53,22 @@ const RankingPlace = styled.div`
   opacity: 0.8;
   ${props => props.feature && 'opacity: 1;'}
 `;
+
 const RankingPlayerName = styled.div`
   color: #e2e9c0;
   opacity: 0.8;
   ${props => props.feature && 'opacity: 1;'}
 `;
-const RankingScore = styled.div`
-  justify-self: center;
-  color: #7aa95c;
+
+const RankingBreakdown = styled.div`
+  display: flex;
+  justify-content: space-evenly;
   opacity: 0.8;
-  ${props => props.feature && 'opacity: 1;'}
+  transition: opacity 500ms ease-in-out;
+
+  ${RankingItem}:hover & {
+    opacity: 1;
+  }
 `;
 
 const Link = styled.a`
@@ -73,21 +80,12 @@ const Link = styled.a`
   text-align: center;
 `;
 
-// const getWinningPercentage = (timesPlayed, timesWon) => {
-//   if (timesPlayed === 0) {
-//     return 0;
-//   }
-
-//   return Math.floor((timesWon / timesPlayed) * 100);
-// };
-
 const View = () => {
   const [rankingList, setRankingList] = useState({ title: '', result: [] });
   const soundService = useContext(GameSoundContext);
   soundService.loadScoreboard();
 
   useEffect(() => {
-    console.log('SOUND', soundService);
     soundService.play(SOUND_KEYS.SCOREBOARD_MUSIC);
     fetchRankings().then(rankings => {
       setRankingList(rankings);
@@ -97,7 +95,6 @@ const View = () => {
   return (
     <FullPage pageTitle="Leaderboard">
       <GameSettingsDrawer />
-      <PageSubTitle>{rankingList.title}</PageSubTitle>
       <RankingScrollableContainer>
         <RankingContainer>
           {rankingList.result.map((ranking, index) => {
@@ -120,7 +117,11 @@ const View = () => {
                   feature={featureRow}
                   style={{ textAlign: 'center' }}
                 >
-                  {featureRow ? '🥇' : `${index + 1}.`}
+                  {featureRow ? (
+                    '🥇'
+                  ) : (
+                    <ReadableNumberFont>{index + 1}.</ReadableNumberFont>
+                  )}
                 </RankingPlace>
                 <RankingPlayerName feature={featureRow}>
                   {featureRow ? (
@@ -129,9 +130,19 @@ const View = () => {
                     ranking.player
                   )}
                 </RankingPlayerName>
-                <RankingScore feature={featureRow}>
-                  {ranking.times_won}
-                </RankingScore>
+                <RankingBreakdown>
+                  <SubStatItem title="Wins" value={ranking.times_won} />
+                  <SubStatItem
+                    type="losses"
+                    title="Losses"
+                    value={ranking.times_lost}
+                  />
+                  <SubStatItem
+                    type="draws"
+                    title="Draws"
+                    value={ranking.times_drawn}
+                  />
+                </RankingBreakdown>
               </RankingItem>
             );
           })}

--- a/src/server/src/stats/player-leaderboard-query.js
+++ b/src/server/src/stats/player-leaderboard-query.js
@@ -1,39 +1,78 @@
-export const playerLeaderboardQuery = `SELECT * FROM
-(SELECT a.player,
+export const playerLeaderboardQuery = `SELECT *
+FROM 
+    (SELECT a.player,
          a.times_played,
          coalesce(b.times_won,
          0) AS times_won,
-         a.total_points
-FROM 
-    (SELECT player1.player,
+         a.total_points,
+         coalesce(c.times_lost,
+         0) AS times_lost,
+         coalesce(d.times_drawn,
+         0) AS times_drawn
+    FROM 
+        (SELECT player1.player,
          count(*) AS times_played,
          sum(player1.points) AS total_points
-    FROM game_result
-    GROUP BY  player1.player) a
-LEFT JOIN 
-    (SELECT player1.player,
+        FROM game_result
+        GROUP BY  player1.player) a
+        LEFT JOIN 
+            (SELECT player1.player,
          count(*) AS times_won
-    FROM game_result
-    WHERE player1.winner
-    GROUP BY  player1.player) b
-    ON a.player=b.player)
-UNION ALL
-(SELECT a.player,
+            FROM game_result
+            WHERE player1.winner
+            GROUP BY  player1.player) b
+                ON a.player=b.player
+            LEFT JOIN 
+                (SELECT player1.player,
+         count(*) AS times_lost
+                FROM game_result
+                WHERE NOT player1.winner
+                        AND NOT result.draw
+                GROUP BY  player1.player) c
+                    ON a.player=c.player
+                LEFT JOIN 
+                    (SELECT player1.player,
+         count(*) AS times_drawn
+                    FROM game_result
+                    WHERE result.draw
+                    GROUP BY  player1.player) d
+                        ON a.player=d.player)
+                UNION ALL
+                (SELECT a.player,
          a.times_played,
          coalesce(b.times_won,
          0) AS times_won,
-         a.total_points
-FROM 
-    (SELECT player2.player,
+         a.total_points,
+         coalesce(c.times_lost,
+         0) AS times_lost,
+         coalesce(d.times_drawn,
+         0) AS times_drawn
+                FROM 
+                    (SELECT player2.player,
          count(*) AS times_played,
          sum(player2.points) AS total_points
-    FROM game_result
-    GROUP BY  player2.player) a
-LEFT JOIN 
-    (SELECT player2.player,
+                    FROM game_result
+                    GROUP BY  player2.player) a
+                    LEFT JOIN 
+                        (SELECT player2.player,
          count(*) AS times_won
-    FROM game_result
-    WHERE player2.winner
-    GROUP BY  player2.player) b
-    ON a.player=b.player)
-    ORDER BY times_won desc, total_points desc, times_played desc, player;`;
+                        FROM game_result
+                        WHERE player2.winner
+                        GROUP BY  player2.player) b
+                            ON a.player=b.player
+                        LEFT JOIN 
+                            (SELECT player2.player,
+         count(*) AS times_lost
+                            FROM game_result
+                            WHERE NOT player2.winner
+                                    AND NOT result.draw
+                            GROUP BY  player2.player) c
+                                ON a.player=c.player
+                            LEFT JOIN 
+                                (SELECT player2.player,
+         count(*) AS times_drawn
+                                FROM game_result
+                                WHERE result.draw
+                                GROUP BY  player2.player) d
+                                    ON a.player=d.player)
+                            ORDER BY  times_won desc, total_points desc, times_played desc, player;`;


### PR DESCRIPTION
![](https://media.giphy.com/media/3o6Mbp6IZJ7nYJR0FG/giphy.gif)

# Why
Show players win/loss/draw totals on leaderboard display

![Screen Shot 2019-05-22 at 8 52 14 pm](https://user-images.githubusercontent.com/35903460/58169345-df6e4400-7cd3-11e9-9dd9-7d03c4f14f51.png)


# How
- Update Athena Query to include total draws
- Show win/loss/draw figures in ranking table