### PR TITLE
Add game history stats page

### DIFF
--- a/src/client/src/App.js
+++ b/src/client/src/App.js
@@ -13,6 +13,7 @@ import {
   ItemSelectionTestScreen,
   IndividualPlayersTest,
   PlayerStats,
+  GameHistory,
 } from './screens';
 import DebugOutput from './DebugOutput';
 import GlobalStyle from './GlobalStyle';
@@ -52,6 +53,7 @@ const App = () => {
                   <PlayerSelectionScreen path="xian" playerKey={'XIAN'} />
                   <PlayerSelectionScreen path="melb" playerKey={'MELB'} />
                   <PlayerStats path="player-stats" />
+                  <GameHistory path="game-history" />
                   <ResetGameScreen path="reset" />
                 </Router>
                 <DebugOutput data={connectionDetails} />

--- a/src/client/src/game-settings/components/settings-drawer/View.js
+++ b/src/client/src/game-settings/components/settings-drawer/View.js
@@ -57,6 +57,7 @@ const View = () => {
       <ThemeCalendar />
       <div>
         <Link href="/player-stats">Go to Leaderboard</Link>
+        <Link href="/game-history">Go to Game History</Link>
       </div>
     </Drawer>
   );

--- a/src/client/src/screens/game-history/SubStatItem.js
+++ b/src/client/src/screens/game-history/SubStatItem.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+import moment from 'moment';
+
+const Container = styled.div`
+  margin: 0;
+  color: white;
+`;
+
+const Date = styled.div`
+  font-size: 0.4rem;
+  margin: 0;
+  padding: 0 0 10px 0;
+  text-align: center;
+  white-space: nowrap;
+  opacity: 0.8;
+`;
+
+const Trophy = styled.div`
+  font-size: 0.6rem;
+  margin: 0;
+  padding: 10px 0 0 0;
+  text-align: center;
+`;
+
+const TeamName = styled.div`
+  margin: 0;
+  padding: 10px 20px;
+  text-align: center;
+  line-height: 1;
+  background-color: ${props => props.style.bgColor};
+  border-radius: 7px;
+  opacity: ${props => props.style.opacity};
+`;
+
+const styles = {
+  player1: {
+    bgColor: '#D4BA6A',
+    opacity: 1,
+  },
+  player2: {
+    bgColor: '#D4886A',
+    opacity: 1,
+  },
+  draw: {
+    bgColor: '#496D89',
+    opacity: 0.7,
+  },
+};
+const mapTeamToName = {
+  player1: 'XIAN',
+  player2: 'MELB',
+};
+
+export const SubStatItem = ({ date, team, draw, trophy }) => {
+  const momentDate = moment(date);
+  const styleKey = draw ? 'draw' : team;
+  const playerName = team ? mapTeamToName[team] : 'DRAW';
+  return (
+    <Container style={styles[styleKey]}>
+      <Date>{momentDate.format('ddd DD MMM, h:mmA')}</Date>
+      {/* <Time>{momentDate.format('h:mmA')}</Time> */}
+      <TeamName style={styles[styleKey]}>{playerName}</TeamName>
+      {trophy && <Trophy>🏆</Trophy>}
+    </Container>
+  );
+};

--- a/src/client/src/screens/game-history/View.js
+++ b/src/client/src/screens/game-history/View.js
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import FullPage from '../../components/page-layout/FullPage';
+import { STATS_API_BASE_URL } from '../../environment';
+import { GameSettingsDrawer } from '../../game-settings';
+import { SubStatItem } from './SubStatItem';
+
+const fetchRankings = () => {
+  return fetch(`${STATS_API_BASE_URL}/game-result-history.json`, {
+    cache: 'no-store',
+  }).then(resp => {
+    return resp.json();
+  });
+};
+
+const ScrollableContainer = styled.div`
+  max-height: 70vh;
+`;
+
+const RankingContainer = styled.div`
+  width: 100vw;
+  display: flex;
+  overflow-x: auto;
+  flex-direction: row-reverse;
+  padding-bottom: 30px;
+
+  &::after {
+    content: ' ';
+    padding-left: 1px;
+  }
+`;
+
+const RankingItem = styled.div`
+  padding: 10px;
+
+  :first-child {
+    margin-right: 35vw;
+  }
+
+  :last-child {
+    margin-left: 50vw;
+  }
+
+  &:nth-child(odd) {
+    background-color: rgba(30, 15, 28, 0.8);
+  }
+
+  &:nth-child(even) {
+    background-color: rgba(30, 15, 28, 0.9);
+  }
+`;
+
+const Link = styled.a`
+  display: block;
+  padding: 20px 0;
+  text-decoration: none;
+  color: inherit;
+  font-size: 0.5em;
+  text-align: center;
+`;
+
+const View = () => {
+  const [rankingList, setRankingList] = useState({ title: '', result: [] });
+
+  useEffect(() => {
+    fetchRankings().then(rankings => {
+      setRankingList(rankings);
+    });
+  }, []);
+
+  return (
+    <FullPage pageTitle="Leaderboard">
+      <GameSettingsDrawer />
+      <ScrollableContainer>
+        <RankingContainer>
+          {rankingList.result.map((ranking, index) => {
+            return (
+              <RankingItem key={index}>
+                <SubStatItem
+                  date={ranking.date}
+                  team={ranking.winner}
+                  draw={ranking.draw}
+                  trophy={ranking.trophy}
+                />
+              </RankingItem>
+            );
+          })}
+        </RankingContainer>
+      </ScrollableContainer>
+      <Link href="/">Back to game</Link>
+    </FullPage>
+  );
+};
+
+export default View;

--- a/src/client/src/screens/game-history/index.js
+++ b/src/client/src/screens/game-history/index.js
@@ -1,0 +1,14 @@
+/* @flow */
+import React from 'react';
+import View from './View';
+import Sound from '../../sounds/Provider';
+import GameSettings from '../../game-settings';
+
+const ViewWithSound = () => (
+  <Sound>
+    <GameSettings>
+      <View />
+    </GameSettings>
+  </Sound>
+);
+export default ViewWithSound;

--- a/src/client/src/screens/index.js
+++ b/src/client/src/screens/index.js
@@ -6,3 +6,4 @@ export { default as PageLayoutScreen } from './page-layout-test';
 export { default as ItemSelectionTestScreen } from './item-selection-test';
 export { default as IndividualPlayersTest } from './individual-players-test';
 export { default as PlayerStats } from './player-stats';
+export { default as GameHistory } from './game-history';

--- a/src/server/src/stats/game-history-query.js
+++ b/src/server/src/stats/game-history-query.js
@@ -1,0 +1,14 @@
+export const gameHistoryQuery = `SELECT
+  date,
+  result.winner AS winner,       
+  CASE
+    WHEN result.draw THEN true
+    ELSE NULL
+  END AS draw,
+  CASE
+    WHEN player1.trophy THEN true
+    WHEN player2.trophy THEN true
+    ELSE NULL
+  END AS trophy
+FROM game_result
+ORDER BY  date desc;`;

--- a/src/server/src/stats/publishStats.js
+++ b/src/server/src/stats/publishStats.js
@@ -8,7 +8,8 @@ import {
   STATS_AWS_RESULT_BUCKET_NAME,
 } from '../environment';
 import { statsS3Bucket } from './s3';
-import {playerLeaderboardQuery} from './player-leaderboard-query';
+import { playerLeaderboardQuery } from './player-leaderboard-query';
+import { gameHistoryQuery } from './game-history-query';
 
 const RESULT_SIZE = 1000;
 const POLL_INTERVAL = 1000;
@@ -31,7 +32,6 @@ let q = Queue((id, cb) => {
     });
 }, 5);
 
-
 /* Make a SQL query and display results */
 const runTestQuery = () => {
   makeQuery(playerLeaderboardQuery)
@@ -41,6 +41,19 @@ const runTestQuery = () => {
         STATS_AWS_RESULT_BUCKET_NAME,
         'players-by-points-ranking.json',
         { result: data, title: 'Ranking by number of games won' }
+      );
+    })
+    .catch(e => {
+      console.log('ERROR: ', e);
+    });
+
+  makeQuery(gameHistoryQuery)
+    .then(data => {
+      console.log('DATA: ', data);
+      statsS3Bucket.saveStats(
+        STATS_AWS_RESULT_BUCKET_NAME,
+        'game-result-history.json',
+        { result: data, title: 'Game result history' }
       );
     })
     .catch(e => {


### PR DESCRIPTION
 # Show game history

![Screen Shot 2019-05-27 at 6 14 11 pm](https://user-images.githubusercontent.com/35903460/58405648-452f4700-80ab-11e9-90b9-0de34026e21e.png)

# Overview of changes

- Publish `game-result-history.json` to **S3** bucket after each game
- Create new page and route at `/game-history`
- Display date, winner and trophy for each game